### PR TITLE
Korjattu GitHub-API -kutsun toimimaan myös muissa haaroissa kuin oletus ja "develop"

### DIFF
--- a/docs/_data/modules/kaavatiedot.yml
+++ b/docs/_data/modules/kaavatiedot.yml
@@ -11,11 +11,13 @@ versions:
   - id: "v1.1"
     title: "Lisätty Kaavamääräysryhmä ja Kaavayksikkö"
     path: "v1.1"
+    git-branch: "branch-1.1"
     default: true
   - id: "dev"
     title: "Seuraava kehitysversio"
     path: "dev"
     development: true
+    git-branch: "develop"
     dependencies:
       - moduleId: "yhteisetkomponentit"
         version: "dev"

--- a/docs/_data/modules/rakennuskohteet.yml
+++ b/docs/_data/modules/rakennuskohteet.yml
@@ -7,6 +7,7 @@ versions:
   - id: "dev"
     title: "Ensimmäinen kehitysversio"
     path: "dev"
+    git-branch: "develop"
     default: true
     development: true
     dependencies:

--- a/docs/_data/modules/rakentamisenluvat.yml
+++ b/docs/_data/modules/rakentamisenluvat.yml
@@ -7,6 +7,7 @@ versions:
   - id: "dev"
     title: "Ensimmäinen kehitysversio"
     path: "dev"
+    git-branch: "develop"
     default: true
     development: true
     dependencies:

--- a/docs/_data/modules/tonttijakosuunnitelma.yml
+++ b/docs/_data/modules/tonttijakosuunnitelma.yml
@@ -10,6 +10,7 @@ versions:
   - id: "dev"
     title: "Seuraava kehitysversio"
     path: "dev"
+    git-branch: "develop"
     development: true
     dependencies:
       - moduleId: "yhteisetkomponentit"

--- a/docs/_data/modules/yhteisetkomponentit.yml
+++ b/docs/_data/modules/yhteisetkomponentit.yml
@@ -7,6 +7,7 @@ versions:
   - id: "dev"
     title: "Ensimmäinen kehitysversio"
     path: "dev"
+    git-branch: "develop"
     default: true
     development: true
 basepath: "ry-yhteiset"


### PR DESCRIPTION
Modulikonfiguraatioin versiotiedoissa nyt annettava eksplisiittisesti tieto "git-branch", mikäli linkattu moduli ei ole git-repon oletushaarasta