### PR TITLE
Lisätty kaupunkiseutusuunnitelman tietomallin dev-versio

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,3 +64,6 @@
 [submodule "docs/rakennusjarjestys/v1.0"]
 	path = docs/rakennusjarjestys/v1.0
 	url = https://github.com/Kuntaliitto/rakennusjarjestys.git
+[submodule "docs/kaupunkiseutusuunnitelma/dev"]
+	path = docs/kaupunkiseutusuunnitelma/dev
+	url = https://github.com/sykefi/kaupunkiseutusuunnitelma.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -67,3 +67,4 @@
 [submodule "docs/kaupunkiseutusuunnitelma/dev"]
 	path = docs/kaupunkiseutusuunnitelma/dev
 	url = https://github.com/sykefi/kaupunkiseutusuunnitelma.git
+	branch = develop

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Sivulle voidaan linkittää mitä tahansa julkisia git-repoja, ja GitHub Pages -
 | Rakennusjärjestys      | dev    | [docs/rakennusjarjestys/](../../tree/main/docs/rakennusjarjestys/)dev | [github.com/Kuntaliitto/rakennusjarjestys](https://github.com/Kuntaliitto/rakennusjarjestys) | develop |  | 
 | Rakennusjärjestys      | 1.0.1    | [docs/rakennusjarjestys/](../../tree/main/docs/rakennusjarjestys/)v1.0 | [github.com/Kuntaliitto/rakennusjarjestys](https://github.com/Kuntaliitto/rakennusjarjestys) | |  |
 | Maankäyttörajoitukset | 1.0    | [docs/maankayttorajoitukset/](../../tree/main/docs/maankayttorajoitukset/)v1.0 | [github.com/sykefi/maankayttorajoitusten-tietomalli](https://github.com/sykefi/maankayttorajoitusten-tietomalli) | |  ei tagiä v1.0.0! | 
-| Maankäyttörajoitukset | dev    | [docs/maankayttorajoitukset/](../../tree/main/docs/maankayttorajoitukset/)dev | [github.com/sykefi/maankayttorajoitusten-tietomalli](https://github.com/sykefi/maankayttorajoitusten-tietomalli) | develop |  | 
+| Maankäyttörajoitukset | dev    | [docs/maankayttorajoitukset/](../../tree/main/docs/maankayttorajoitukset/)dev | [github.com/sykefi/maankayttorajoitusten-tietomalli](https://github.com/sykefi/maankayttorajoitusten-tietomalli) | develop |  |
+| Kaupunkiseutusuunnitelma      | dev    | [docs/kaupunkiseutusuunnitelma/](../../tree/main/docs/kaupunkiseutusuunnitelma/)dev | [github.com/sykefi/kaupunkiseutusuunnitelma](https://github.com/sykefi/kaupunkiseutusuunnitelma) | develop |  |
 
 Kulloinkin linkatut git submodulet ja niiden tilan saa tulostettua (linux-tyyppisessä komentoriviympäristössä) seuraavalla loitsulla:
 ```sh
@@ -47,7 +48,6 @@ Seuraavassa listassa on lueteltu [rakennetun ympäristön yhteentoimivuustyöss�
    * Yleisten alueiden suunnitelmat
    * Kaavatietomallin soveltamisprofiili maakuntakaavoille
    * Merialuesuunnitelma
-   * Kaupunkiseutusuunnitelma
 * Kulttuuriympäristö
    * Rakennettu kulttuuriympäristö
    * Rakennusperinnön ja arkeologisen kulttuuriperinnön suojelu

--- a/docs/_data/modules/kaupunkiseutusuunnitelma.yml
+++ b/docs/_data/modules/kaupunkiseutusuunnitelma.yml
@@ -1,1 +1,46 @@
 title: "Kaupunkiseutusuunnitelma"
+ownership: "ympäristöministeriö"
+github:
+  owner_name: "sykefi"
+  repository_name: "kaupunkiseutusuunnitelma"
+versions:
+  - id: "dev"
+    title: "Seuraava kehitysversio"
+    path: "dev"
+    default: true
+    development: true
+    git-branch: "develop"
+    dependencies:
+      - moduleId: "yhteisetkomponentit"
+        version: "dev"
+basepath: "kaupunkiseutusuunnitelma"
+nav_items:
+  - pageId: "johdanto"
+    title: "Johdanto"
+    path: ""
+    gitHubFile: "index.md"
+    default: true
+  - pageId: "kasitemalli"
+    title: "Käsitemalli"
+  - groupId: "looginenmalli"
+    title: "Looginen tietomalli"
+    nav_items:
+      - pageId: "dokumentaatio"
+        title: "Dokumentaatio"
+      - pageId: "uml-doc"
+        title: "UML-kaaviot"
+        path: "uml/doc/"
+        # tiedostona XMI/zip, jotta muutosmetatiedot päivittyvät
+        gitHubFile: "uml/kaupunkiseutusuunnitelma.xml"
+      - pageId: "elinkaarisaannot"
+        title: "Elinkaarisäännöt"
+        gitHubFile: "elinkaarisaannot.md"
+        path: "elinkaarisaannot.html"
+      - pageId: "laatusaannot"
+        title: "Laatusäännöt"
+        gitHubFile: "laatusaannot.md"
+        path: "laatusaannot.html"
+  - pageId: "muutosloki"
+    title: "Muutosloki"
+    path: "muutosloki.html"
+    gitHubFile: "muutosloki.md"


### PR DESCRIPTION
Linkitetty GitHub-repon https://github.com/sykefi/kaupunkiseutusuunnitelma develop-haarasta. Commitin https://github.com/sykefi/kaupunkiseutusuunnitelma/commit/2aeb869d878e9d41aac10f3bf60f9102e1f65333 mukainen kehitysversio tietomallista tässä mukana.