### PR TITLE
Poistettu Kaupunkiseutusuunnitelma dev-versio

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,10 +64,6 @@
 [submodule "docs/rakennusjarjestys/v1.0"]
 	path = docs/rakennusjarjestys/v1.0
 	url = https://github.com/Kuntaliitto/rakennusjarjestys.git
-[submodule "docs/kaupunkiseutusuunnitelma/dev"]
-	path = docs/kaupunkiseutusuunnitelma/dev
-	url = https://github.com/sykefi/kaupunkiseutusuunnitelma.git
-	branch = develop
 [submodule "docs/kaupunkiseutusuunnitelma/v1.0"]
 	path = docs/kaupunkiseutusuunnitelma/v1.0
 	url = https://github.com/sykefi/kaupunkiseutusuunnitelma.git

--- a/docs/_data/modules/kaupunkiseutusuunnitelma.yml
+++ b/docs/_data/modules/kaupunkiseutusuunnitelma.yml
@@ -11,14 +11,6 @@ versions:
     dependencies:
       - moduleId: "yhteisetkomponentit"
         version: "dev"
-  - id: "dev"
-    title: "Seuraava kehitysversio"
-    path: "dev"
-    development: true
-    git-branch: "develop"
-    dependencies:
-      - moduleId: "yhteisetkomponentit"
-        version: "dev"
 basepath: "kaupunkiseutusuunnitelma"
 nav_items:
   - pageId: "johdanto"


### PR DESCRIPTION
GitHub Pages -palvelussa [sivuston maksimikoko on 1GB](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#usage-limits). Kaupunkiseutusuunnitelman version 1.0 julkaisu sai tietomallit.ymparisto.fi -sivuston koon ylittämään 1GB rajan, eikä sen julkaisu enää onnistunut GitHub Pages -palvelussa. 

Väliaikaisratkaisuna poistettu Kaupunkiseutusuunnitelma dev-versio sivustolta.